### PR TITLE
Set global fermi state from system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ keywords = ["declarative-ui", "ecs", "bevy", "dioxus", "cross-platform"]
 
 [dependencies]
 bevy = { version = "0.7", default-features = false }
+bevy_dioxus_core = { version = "0.1", path = "./packages/core" }
 bevy_dioxus_desktop = { version = "0.1", path = "./packages/desktop", optional = true }
+bevy_dioxus_macro = { version = "0.1", path = "./packages/macro" }
 
 [dev-dependencies]
 leafwing-input-manager = { version = "0.3", default-features = false }
@@ -24,7 +26,9 @@ desktop = ["bevy_dioxus_desktop"]
 
 [workspace]
 members = [
+    "packages/core",
     "packages/desktop",
+    "packages/macro",
 ]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy_dioxus_desktop = { version = "0.1", path = "./packages/desktop", optional =
 
 [dev-dependencies]
 leafwing-input-manager = { version = "0.3", default-features = false }
-dioxus = "0.2"
+dioxus = { version = "0.2", features = ["fermi"] }
 
 [features]
 default = ["desktop"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <p>Write Cross-platform application with React-like decralative UI framework<br/>and scalable ECS architecture all in Rust.</p>
     <p align="center">
      <a href="https://docs.rs/bevy_dioxus/latest/bevy_dioxus/" alt="API Refenrence">
-        <img src="https://img.shields.io/badge/API Reference-000?style=for-the-badge" />
+        <img src="https://img.shields.io/badge/API Reference-000?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" />
      </a>
      <!-- Link to Guide -->
     </p>
@@ -41,7 +41,7 @@ fn main() {
             title: "Bevy Dioxus Plugin Example".to_string(),
             ..Default::default()
         })
-        .add_plugin(DioxusPlugin::<(), ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), ()>::new(Root))
         .run();
 }
 

--- a/examples/core-state.rs
+++ b/examples/core-state.rs
@@ -1,0 +1,87 @@
+use bevy::{log::LogPlugin, prelude::*};
+use bevy_dioxus::desktop::prelude::*;
+use dioxus::prelude::*;
+
+fn main() {
+    App::new()
+        .insert_resource(WindowDescriptor {
+            title: "Counter".to_string(),
+            ..Default::default()
+        })
+        .add_plugin(LogPlugin)
+        .add_plugin(DioxusPlugin::<CoreCommand, ()>::new(Root))
+        .add_startup_system(setup)
+        .add_system(handle_core_cmd)
+        .add_system(update_count_atom)
+        .run();
+}
+
+#[derive(Clone, Debug)]
+enum CoreCommand {
+    Increment,
+    Decrement,
+    Reset,
+}
+
+fn setup(mut commands: Commands) {
+    info!("🧠 Spawn count");
+    commands.spawn().insert(Count::default());
+}
+
+// TODO: should be derived by macro
+fn update_count_atom(query: Query<&Count, Changed<Count>>) {
+    for count in query.iter() {
+        info!("🧠 Counter Changed: {}", count.0);
+        // ui.send(UiCommand::CountChanged(count.0));
+    }
+}
+
+fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<&mut Count>) {
+    for cmd in events.iter() {
+        let mut count = query.single_mut();
+        match cmd {
+            CoreCommand::Increment => {
+                info!("🧠 Increment");
+                count.0 += 1;
+            }
+            CoreCommand::Decrement => {
+                if count.0 > 0 {
+                    info!("🧠 Decrement");
+                    count.0 -= 1;
+                }
+            }
+            CoreCommand::Reset => {
+                if count.0 != 0 {
+                    info!("🧠 Reset");
+                    count.0 = 0;
+                }
+            }
+        }
+    }
+}
+
+#[allow(non_snake_case)]
+fn Root(cx: Scope) -> Element {
+    let window = use_window::<CoreCommand, ()>(&cx);
+    let count = use_read(&cx, COUNT);
+    let disabled = count.0 == 0;
+
+    cx.render(rsx! {
+        h1 { "Counter Example" }
+        p { "count: {count.0}" }
+        button {
+            onclick: move |_| window.send(CoreCommand::Decrement),
+            disabled: "{disabled}",
+            "-",
+        }
+        button {
+            onclick: move |_| window.send(CoreCommand::Reset),
+            disabled: "{disabled}",
+            "Reset"
+        }
+        button {
+            onclick: move |_| window.send(CoreCommand::Increment),
+            "+",
+        }
+    })
+}

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -9,7 +9,7 @@ fn main() {
             ..Default::default()
         })
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<CoreCommand, UiCommand>::new(Root))
+        .add_plugin(DioxusPlugin::<CoreCommand, UiCommand, ()>::new(Root))
         .add_startup_system(spawn_count)
         .add_system(handle_core_cmd)
         .add_system_to_stage(CoreStage::PostUpdate, notify_counter_change)

--- a/examples/desktop.rs
+++ b/examples/desktop.rs
@@ -44,7 +44,7 @@ fn main() {
             title: "Bevy Dioxus Plugin Demo".to_string(),
             ..Default::default()
         })
-        .add_plugin(DioxusPlugin::<CoreCommand, UiCommand>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, CoreCommand, UiCommand>::new(Root))
         .add_plugin(LogPlugin)
         .add_system(send_keyboard_input)
         .add_system(handle_core_command)

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -92,7 +92,9 @@ fn update_count_atom(
         }
     }
     for disabled in disabled.iter() {
-        match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::Disabled(disabled.clone()))) {
+        match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::Disabled(
+            disabled.clone(),
+        ))) {
             Ok(()) => {}
             Err(e) => match e {
                 TrySendError::Full(e) => {
@@ -112,7 +114,10 @@ fn update_count_atom(
     }
 }
 
-fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<(&mut Count, &mut Disabled)>) {
+fn handle_core_cmd(
+    mut events: EventReader<CoreCommand>,
+    mut query: Query<(&mut Count, &mut Disabled)>,
+) {
     for cmd in events.iter() {
         let (mut count, mut disabled) = query.single_mut();
         match cmd {

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -1,4 +1,4 @@
-use bevy::{log::LogPlugin, prelude::*};
+use bevy::{log::LogPlugin, prelude::*, window::RequestRedraw};
 use bevy_dioxus::desktop::prelude::*;
 use dioxus::{fermi::Readable, prelude::*};
 
@@ -19,7 +19,7 @@ fn main() {
 #[derive(Component, Default, Clone)]
 pub struct Count(pub u32);
 
-pub static COUNT: Atom<Count> = |_| Count::default();
+pub static COUNT: Atom<Count> = |_| Count(100);
 
 #[derive(Clone, Debug)]
 enum CoreCommand {
@@ -62,6 +62,7 @@ fn update_count_atom(query: Query<&Count, Changed<Count>>, vdom_tx: Res<Sender<V
 
 fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<&mut Count>) {
     for cmd in events.iter() {
+        info!("core cmd");
         let mut count = query.single_mut();
         match cmd {
             CoreCommand::Increment => {

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -12,7 +12,8 @@ fn main() {
         .add_plugin(DioxusPlugin::<CoreCommand, (), GlobalState>::new(Root))
         .add_startup_system(setup)
         .add_system(handle_core_cmd.label("handle-core-cmd"))
-        .add_system(update_count_atom.after("handle-core-cmd"))
+        .add_system(apply_count.after("handle-core-cmd"))
+        .add_system(apply_disabled.after("handle-core-cmd"))
         .run();
 }
 
@@ -67,9 +68,8 @@ fn setup(mut commands: Commands) {
 }
 
 // TODO: should be derived by macro
-fn update_count_atom(
+fn apply_count(
     counts: Query<&Count, Changed<Count>>,
-    disabled: Query<&Disabled, Changed<Disabled>>,
     vdom_tx: Res<Sender<VDomCommand<GlobalState>>>,
 ) {
     for count in counts.iter() {
@@ -91,6 +91,12 @@ fn update_count_atom(
             },
         }
     }
+}
+
+fn apply_disabled(
+    disabled: Query<&Disabled, Changed<Disabled>>,
+    vdom_tx: Res<Sender<VDomCommand<GlobalState>>>,
+) {
     for disabled in disabled.iter() {
         match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::Disabled(
             disabled.clone(),

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -1,6 +1,6 @@
 use bevy::{log::LogPlugin, prelude::*};
 use bevy_dioxus::desktop::prelude::*;
-use dioxus::prelude::*;
+use dioxus::{fermi::Readable, prelude::*};
 
 fn main() {
     App::new()
@@ -11,10 +11,15 @@ fn main() {
         .add_plugin(LogPlugin)
         .add_plugin(DioxusPlugin::<CoreCommand, ()>::new(Root))
         .add_startup_system(setup)
-        .add_system(handle_core_cmd)
-        .add_system(update_count_atom)
+        .add_system(handle_core_cmd.label("handle-core-cmd"))
+        .add_system(update_count_atom.after("handle-core-cmd"))
         .run();
 }
+
+#[derive(Component, Default, Clone)]
+pub struct Count(pub u32);
+
+pub static COUNT: Atom<Count> = |_| Count::default();
 
 #[derive(Clone, Debug)]
 enum CoreCommand {
@@ -29,10 +34,31 @@ fn setup(mut commands: Commands) {
 }
 
 // TODO: should be derived by macro
-fn update_count_atom(query: Query<&Count, Changed<Count>>) {
+fn update_count_atom(query: Query<&Count, Changed<Count>>, vdom_tx: Res<Sender<VDomCommand>>) {
     for count in query.iter() {
         info!("🧠 Counter Changed: {}", count.0);
-        // ui.send(UiCommand::CountChanged(count.0));
+        match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::new(
+            COUNT.unique_id() as usize,
+            Box::new(count.clone()),
+        ))) {
+            Ok(()) => {
+                println!("send ok");
+            }
+            Err(e) => match e {
+                TrySendError::Full(e) => {
+                    error!(
+                        "Failed to send VDomCommand: channel is full: event: {:?}",
+                        e
+                    );
+                }
+                TrySendError::Closed(e) => {
+                    error!(
+                        "Failed to send VDomCommand: channel is closed: event: {:?}",
+                        e
+                    );
+                }
+            },
+        }
     }
 }
 

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -41,9 +41,7 @@ fn update_count_atom(query: Query<&Count, Changed<Count>>, vdom_tx: Res<Sender<V
             COUNT.unique_id() as usize,
             Box::new(count.clone()),
         ))) {
-            Ok(()) => {
-                println!("send ok");
-            }
+            Ok(()) => {}
             Err(e) => match e {
                 TrySendError::Full(e) => {
                     error!(

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -1,21 +1,55 @@
 use bevy::{log::LogPlugin, prelude::*};
 use bevy_dioxus::desktop::prelude::*;
-use dioxus::{fermi::Readable, prelude::*};
+use dioxus::{
+    fermi::{AtomRoot, Readable},
+    prelude::*,
+};
+use std::rc::Rc;
 
 fn main() {
     App::new()
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<CoreCommand, (), Count>::new(Root))
+        .add_plugin(DioxusPlugin::<CoreCommand, (), GlobalState>::new(Root))
         .add_startup_system(setup)
         .add_system(handle_core_cmd.label("handle-core-cmd"))
         .add_system(update_count_atom.after("handle-core-cmd"))
         .run();
 }
 
-#[derive(Component, Default, Clone, Debug)]
-pub struct Count(pub u32);
+#[derive(Component, Clone, Debug, Default)]
+struct Count(pub u32);
 
-pub static COUNT: Atom<Count> = |_| Count(0);
+#[derive(Component, Clone, Debug)]
+struct Disabled(bool);
+
+impl Default for Disabled {
+    fn default() -> Self {
+        Self(true)
+    }
+}
+
+// TODO: derive by macro ?
+static COUNT: Atom<Count> = |_| Count::default();
+static DISABLED: Atom<Disabled> = |_| Disabled::default();
+
+#[derive(Debug)]
+enum GlobalState {
+    Count(Count),
+    Disabled(Disabled),
+}
+
+impl GlobalStateHandler<GlobalState> for GlobalState {
+    fn handler(root: Rc<AtomRoot>, state: GlobalState) {
+        match state {
+            GlobalState::Count(count) => {
+                root.set(COUNT.unique_id(), count);
+            }
+            GlobalState::Disabled(disabled) => {
+                root.set(DISABLED.unique_id(), disabled);
+            }
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 enum CoreCommand {
@@ -26,20 +60,39 @@ enum CoreCommand {
 
 fn setup(mut commands: Commands) {
     info!("🧠 Spawn count");
-    commands.spawn().insert(Count::default());
+    commands
+        .spawn()
+        .insert(Count::default())
+        .insert(Disabled::default());
 }
 
 // TODO: should be derived by macro
 fn update_count_atom(
-    query: Query<&Count, Changed<Count>>,
-    vdom_tx: Res<Sender<VDomCommand<Count>>>,
+    counts: Query<&Count, Changed<Count>>,
+    disabled: Query<&Disabled, Changed<Disabled>>,
+    vdom_tx: Res<Sender<VDomCommand<GlobalState>>>,
 ) {
-    for count in query.iter() {
-        info!("🧠 Counter Changed: {}", count.0);
-        match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::new(
-            COUNT.unique_id() as usize,
-            count.clone(),
-        ))) {
+    for count in counts.iter() {
+        match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::Count(count.clone()))) {
+            Ok(()) => {}
+            Err(e) => match e {
+                TrySendError::Full(e) => {
+                    error!(
+                        "Failed to send VDomCommand: channel is full: event: {:?}",
+                        e
+                    );
+                }
+                TrySendError::Closed(e) => {
+                    error!(
+                        "Failed to send VDomCommand: channel is closed: event: {:?}",
+                        e
+                    );
+                }
+            },
+        }
+    }
+    for disabled in disabled.iter() {
+        match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::Disabled(disabled.clone()))) {
             Ok(()) => {}
             Err(e) => match e {
                 TrySendError::Full(e) => {
@@ -59,9 +112,9 @@ fn update_count_atom(
     }
 }
 
-fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<&mut Count>) {
+fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<(&mut Count, &mut Disabled)>) {
     for cmd in events.iter() {
-        let mut count = query.single_mut();
+        let (mut count, mut disabled) = query.single_mut();
         match cmd {
             CoreCommand::Increment => {
                 info!("🧠 Increment");
@@ -79,7 +132,8 @@ fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<&mut C
                     count.0 = 0;
                 }
             }
-        }
+        };
+        disabled.0 = count.0 == 0;
     }
 }
 
@@ -87,19 +141,19 @@ fn handle_core_cmd(mut events: EventReader<CoreCommand>, mut query: Query<&mut C
 fn Root(cx: Scope) -> Element {
     let window = use_window::<CoreCommand, ()>(&cx);
     let count = use_read(&cx, COUNT);
-    let disabled = count.0 == 0;
+    let disabled = use_read(&cx, DISABLED);
 
     cx.render(rsx! {
         h1 { "Counter Example" }
         p { "count: {count.0}" }
         button {
             onclick: move |_| window.send(CoreCommand::Decrement),
-            disabled: "{disabled}",
+            disabled: "{disabled.0}",
             "-",
         }
         button {
             onclick: move |_| window.send(CoreCommand::Reset),
-            disabled: "{disabled}",
+            disabled: "{disabled.0}",
             "Reset"
         }
         button {

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -12,10 +12,7 @@ fn main() {
         .run();
 }
 
-#[derive(Component, Default, Clone)]
-pub struct Count(pub u32);
-
-pub static COUNT: Atom<Count> = |_| Count(100);
+pub static COUNT: Atom<Count> = |_| Count(0);
 
 #[derive(Clone, Debug)]
 enum CoreCommand {

--- a/examples/global-state.rs
+++ b/examples/global-state.rs
@@ -1,13 +1,9 @@
-use bevy::{log::LogPlugin, prelude::*, window::RequestRedraw};
+use bevy::{log::LogPlugin, prelude::*};
 use bevy_dioxus::desktop::prelude::*;
 use dioxus::{fermi::Readable, prelude::*};
 
 fn main() {
     App::new()
-        .insert_resource(WindowDescriptor {
-            title: "Counter".to_string(),
-            ..Default::default()
-        })
         .add_plugin(LogPlugin)
         .add_plugin(DioxusPlugin::<CoreCommand, ()>::new(Root))
         .add_startup_system(setup)

--- a/examples/key-bindings.rs
+++ b/examples/key-bindings.rs
@@ -20,7 +20,7 @@ fn main() {
             ..Default::default()
         })
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<(), ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), ()>::new(Root))
         .add_plugin(CorePlugin)
         .add_plugin(InputManagerPlugin::<Action>::default())
         .add_startup_system(setup)

--- a/examples/keyboard-event.rs
+++ b/examples/keyboard-event.rs
@@ -9,7 +9,7 @@ fn main() {
             ..Default::default()
         })
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<CoreCommand, ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, CoreCommand, ()>::new(Root))
         .add_startup_system(setup)
         .add_system(handle_core_cmd)
         .add_system(log_keyboard_event)

--- a/examples/minimum.rs
+++ b/examples/minimum.rs
@@ -8,7 +8,7 @@ fn main() {
             title: "Minimum Example".to_string(),
             ..Default::default()
         })
-        .add_plugin(DioxusPlugin::<(), ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), ()>::new(Root))
         .run();
 }
 

--- a/examples/ping-pong.rs
+++ b/examples/ping-pong.rs
@@ -8,7 +8,7 @@ fn main() {
             title: "Ping-Pong Example".to_string(),
             ..Default::default()
         })
-        .add_plugin(DioxusPlugin::<CoreCommand, UiCommand>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, CoreCommand, UiCommand>::new(Root))
         .add_plugin(LogPlugin)
         .add_system(pong)
         .run();

--- a/examples/root-props.rs
+++ b/examples/root-props.rs
@@ -8,7 +8,9 @@ fn main() {
             title: "Props Example".to_string(),
             ..Default::default()
         })
-        .add_plugin(DioxusPlugin::<(), (), RootProps>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), (), RootProps>::new(
+            Root,
+        ))
         .add_plugin(LogPlugin)
         .run();
 }

--- a/examples/window/multiple-windows.rs
+++ b/examples/window/multiple-windows.rs
@@ -10,7 +10,7 @@ use dioxus::prelude::*;
 fn main() {
     App::new()
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<NewWindow, ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, NewWindow, ()>::new(Root))
         .add_event::<NewWindow>()
         .add_system(create_new_window)
         .run();

--- a/examples/window/scale-factor-override.rs
+++ b/examples/window/scale-factor-override.rs
@@ -2,7 +2,7 @@ use bevy::{log::LogPlugin, prelude::*};
 use bevy_dioxus::desktop::prelude::*;
 use dioxus::prelude::*;
 
-/// This example attemps to create a second window then warning shows up
+/// This example open window with specific size then resize
 fn main() {
     App::new()
         .insert_resource(WindowDescriptor {
@@ -11,7 +11,7 @@ fn main() {
             ..default()
         })
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<(), ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), ()>::new(Root))
         .add_system(toggle_override)
         .add_system(change_scale_factor)
         .run();

--- a/examples/window/settings.rs
+++ b/examples/window/settings.rs
@@ -14,7 +14,7 @@ fn main() {
         })
         .add_plugin(CorePlugin)
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<(), ()>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), ()>::new(Root))
         .add_system(change_title)
         .add_system(toggle_cursor)
         // .add_system(cycle_cursor_icon)

--- a/examples/window/update-mode.rs
+++ b/examples/window/update-mode.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .add_plugin(CorePlugin)
         .add_plugin(LogPlugin)
-        .add_plugin(DioxusPlugin::<(), UiCommand>::new(Root))
+        .add_plugin(DioxusPlugin::<EmptyGlobalState, (), UiCommand>::new(Root))
         .add_plugin(InputManagerPlugin::<Action>::default())
         .add_startup_system(setup)
         .add_system(update_frame)

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bevy_dioxus_core"
+version = "0.1.0"
+authors = ["Junichi Sugiura"]
+edition = "2021"
+description = "Write Cross-platform application with React-like decralative UI framework and scalable ECS architecture all in Rust."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/JunichiSugiura/bevy_dioxus/"
+homepage = "https://github.com/JunichiSugiura/bevy_dioxus/"
+documentation = "https://docs.rs/bevy_dioxus/latest/bevy_dioxus/"
+keywords = ["declarative-ui", "ecs", "bevy", "dioxus", "cross-platform"]
+
+[dependencies]
+bevy_dioxus_macro = { version = "0.1", path = "../macro"}
+fermi = "0.2"

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -1,0 +1,22 @@
+//! Shared resources across platforms
+
+use fermi::AtomRoot;
+use std::rc::Rc;
+
+/// Trait to provide custom handerl for global states. This trait is automatically implemented with GlobalStatePlugin macro.
+pub trait GlobalStateHandler {
+    ///
+    fn handler(self, _atom_root: Rc<AtomRoot>);
+}
+
+/// Placeholder
+pub struct EmptyGlobalState;
+
+impl GlobalStateHandler for EmptyGlobalState {
+    fn handler(self, _atom_root: Rc<AtomRoot>) {}
+}
+
+pub mod prelude {
+    pub use crate::{EmptyGlobalState, GlobalStateHandler};
+    pub use bevy_dioxus_macro::{GlobalState, GlobalStatePlugin};
+}

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["declarative-ui", "ecs", "bevy", "dioxus", "cross-platform"]
 [dependencies]
 approx = "0.5.1"
 bevy = { version = "0.7", default-features = false }
+bevy_dioxus_core = { version = "0.1", path = "../core"}
 core-foundation = "0.9"
 dioxus-core = { version = "0.2", features = ["serialize"] }
 dioxus-hooks = "0.2"

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -28,6 +28,6 @@ raw-window-handle = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"
-tokio = { version = "1.18", features = ["rt-multi-thread"], default-features = false }
+tokio = { version = "1.18", features = ["rt-multi-thread", "macros"], default-features = false }
 webbrowser = "0.5"
 wry = "0.16"

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -19,6 +19,7 @@ dioxus-hooks = "0.2"
 dioxus-html = { version = "0.2", features = ["serialize"] }
 dioxus-interpreter-js = "0.2"
 dunce = "1.0"
+fermi = "0.2"
 futures-channel = "0.3.21"
 futures-intrusive = "0.4"
 log = "0.4"

--- a/packages/desktop/src/event.rs
+++ b/packages/desktop/src/event.rs
@@ -129,33 +129,13 @@ pub enum WindowEvent {
 
 /// Event to control VirtualDom from outside
 #[derive(Debug)]
-pub enum VDomCommand<V> {
+pub enum VDomCommand<GlobalState> {
     /// Apply all edits
     UpdateDom,
 
     /// Set global state
-    GlobalState(GlobalState<V>),
+    GlobalState(GlobalState),
 }
-
-/// Set global state
-#[derive(Debug)]
-pub struct GlobalState<V> {
-    /// AtomId of target global state to modify
-    pub id: usize,
-    /// new value to set as global state
-    pub value: V,
-}
-
-impl<V> GlobalState<V> {
-    /// Instanciate new GlobalState
-    pub fn new(id: usize, value: V) -> Self {
-        Self { id, value }
-    }
-}
-
-// /// Event which lets VirtualDom to apply all edits
-// #[derive(Debug, Clone)]
-// pub struct UpdateDom;
 
 /// Rust representation of web KeyboardEvent
 #[derive(Debug, Clone, Deserialize)]

--- a/packages/desktop/src/event.rs
+++ b/packages/desktop/src/event.rs
@@ -9,7 +9,7 @@ use dioxus_core::{ElementId, EventPriority, UserEvent};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_repr::*;
-use std::{any::Any, fmt::Debug};
+use std::fmt::Debug;
 
 /// Tao events that emit from UI side
 #[derive(Debug)]
@@ -129,26 +129,26 @@ pub enum WindowEvent {
 
 /// Event to control VirtualDom from outside
 #[derive(Debug)]
-pub enum VDomCommand {
+pub enum VDomCommand<V> {
     /// Apply all edits
     UpdateDom,
 
     /// Set global state
-    GlobalState(GlobalState),
+    GlobalState(GlobalState<V>),
 }
 
-#[derive(Debug)]
 /// Set global state
-pub struct GlobalState {
+#[derive(Debug)]
+pub struct GlobalState<V> {
     /// AtomId of target global state to modify
     pub id: usize,
     /// new value to set as global state
-    pub value: Box<dyn Any + Send + Sync>,
+    pub value: V,
 }
 
-impl GlobalState {
+impl<V> GlobalState<V> {
     /// Instanciate new GlobalState
-    pub fn new(id: usize, value: Box<dyn Any + Send + Sync>) -> Self {
+    pub fn new(id: usize, value: V) -> Self {
         Self { id, value }
     }
 }

--- a/packages/desktop/src/event.rs
+++ b/packages/desktop/src/event.rs
@@ -9,7 +9,7 @@ use dioxus_core::{ElementId, EventPriority, UserEvent};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_repr::*;
-use std::fmt::Debug;
+use std::{any::Any, fmt::Debug};
 
 /// Tao events that emit from UI side
 #[derive(Debug)]
@@ -127,9 +127,35 @@ pub enum WindowEvent {
     Eval(String),
 }
 
-/// Event which lets VirtualDom to apply all edits
-#[derive(Debug, Clone)]
-pub struct UpdateDom;
+/// Event to control VirtualDom from outside
+#[derive(Debug)]
+pub enum VDomCommand {
+    /// Apply all edits
+    UpdateDom,
+
+    /// Set global state
+    GlobalState(GlobalState),
+}
+
+#[derive(Debug)]
+/// Set global state
+pub struct GlobalState {
+    /// AtomId of target global state to modify
+    pub id: usize,
+    /// new value to set as global state
+    pub value: Box<dyn Any + Send + Sync>,
+}
+
+impl GlobalState {
+    /// Instanciate new GlobalState
+    pub fn new(id: usize, value: Box<dyn Any + Send + Sync>) -> Self {
+        Self { id, value }
+    }
+}
+
+// /// Event which lets VirtualDom to apply all edits
+// #[derive(Debug, Clone)]
+// pub struct UpdateDom;
 
 /// Rust representation of web KeyboardEvent
 #[derive(Debug, Clone, Deserialize)]

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -14,11 +14,12 @@ mod window;
 
 pub mod prelude {
     //! This module includes plugin, settings, events, and hooks.
+
     pub use crate::{
         event::*,
         hooks::*,
         plugin::DioxusPlugin,
         setting::{DioxusSettings, UpdateMode},
-        window::{Count, COUNT},
     };
+    pub use futures_intrusive::channel::{shared::Sender, TrySendError};
 }

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude {
     pub use crate::{
         event::*,
         hooks::*,
-        plugin::DioxusPlugin,
+        plugin::{DioxusPlugin, GlobalStateHandler},
         setting::{DioxusSettings, UpdateMode},
     };
     pub use futures_intrusive::channel::{shared::Sender, TrySendError};

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -1,4 +1,4 @@
-//! Build desktop app
+//! For build desktop application
 
 #![deny(missing_docs)]
 
@@ -18,8 +18,9 @@ pub mod prelude {
     pub use crate::{
         event::*,
         hooks::*,
-        plugin::{DioxusPlugin, GlobalStateHandler},
+        plugin::DioxusPlugin,
         setting::{DioxusSettings, UpdateMode},
     };
+    pub use bevy_dioxus_core::prelude::*;
     pub use futures_intrusive::channel::{shared::Sender, TrySendError};
 }

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -19,5 +19,6 @@ pub mod prelude {
         hooks::*,
         plugin::DioxusPlugin,
         setting::{DioxusSettings, UpdateMode},
+        window::{Count, COUNT},
     };
 }

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude {
     pub use crate::{
         event::*,
         hooks::*,
-        plugin::{DioxusPlugin, Count},
+        plugin::DioxusPlugin,
         setting::{DioxusSettings, UpdateMode},
     };
     pub use futures_intrusive::channel::{shared::Sender, TrySendError};

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude {
     pub use crate::{
         event::*,
         hooks::*,
-        plugin::DioxusPlugin,
+        plugin::{DioxusPlugin, Count},
         setting::{DioxusSettings, UpdateMode},
     };
     pub use futures_intrusive::channel::{shared::Sender, TrySendError};

--- a/packages/desktop/src/plugin.rs
+++ b/packages/desktop/src/plugin.rs
@@ -166,6 +166,13 @@ where
             proxy
                 .send_event(UiEvent::WindowEvent(WindowEvent::Update))
                 .unwrap();
+            let cx = vdom.base_scope();
+            let root = match cx.consume_context::<Rc<AtomRoot>>() {
+                Some(root) => root,
+                None => cx.provide_root_context(Rc::new(AtomRoot::new(
+                    cx.schedule_update_any(),
+                ))),
+                };
 
             Runtime::new().unwrap().block_on(async move {
                 let mut count = 0;
@@ -190,13 +197,6 @@ where
                                     VDomCommand::UpdateDom => {
                                     }
                                     VDomCommand::GlobalState(state) => {
-                                        let cx = vdom.base_scope();
-                                        let root = match cx.consume_context::<Rc<AtomRoot>>() {
-                                            Some(root) => root,
-                                            None => cx.provide_root_context(Rc::new(AtomRoot::new(
-                                                cx.schedule_update_any(),
-                                            ))),
-                                        };
                                         println!("set atom id: {:?}, value: {:?}", state.id as AtomId, state.value);
                                         root.set(state.id as AtomId, Count(count));
                                         count += 1;

--- a/packages/desktop/src/plugin.rs
+++ b/packages/desktop/src/plugin.rs
@@ -47,6 +47,10 @@ pub struct DioxusPlugin<CoreCommand, UiCommand, Props = ()> {
     ui_cmd_type: PhantomData<UiCommand>,
 }
 
+#[derive(Component, Default, Clone)]
+///
+pub struct Count(pub u32);
+
 impl<CoreCommand, UiCommand, Props> Plugin for DioxusPlugin<CoreCommand, UiCommand, Props>
 where
     CoreCommand: 'static + Send + Sync + Clone + Debug,
@@ -164,6 +168,7 @@ where
                 .unwrap();
 
             Runtime::new().unwrap().block_on(async move {
+                let mut count = 0;
                 loop {
                     select! {
                         () = vdom.wait_for_work() => {
@@ -186,13 +191,15 @@ where
                                     }
                                     VDomCommand::GlobalState(state) => {
                                         let cx = vdom.base_scope();
-                                        let _root = match cx.consume_context::<Rc<AtomRoot>>() {
+                                        let root = match cx.consume_context::<Rc<AtomRoot>>() {
                                             Some(root) => root,
                                             None => cx.provide_root_context(Rc::new(AtomRoot::new(
                                                 cx.schedule_update_any(),
                                             ))),
                                         };
-                                        println!("set atom id: {:?}, value: {:?}",state.id as AtomId, state.value);
+                                        println!("set atom id: {:?}, value: {:?}", state.id as AtomId, state.value);
+                                        root.set(state.id as AtomId, Count(count));
+                                        count += 1;
                                     }
                                 }
 

--- a/packages/desktop/src/plugin.rs
+++ b/packages/desktop/src/plugin.rs
@@ -81,7 +81,6 @@ where
             .insert_non_send_resource(EventLoop::<UiEvent<CoreCommand>>::with_user_event())
             .set_runner(|app| runner::<CoreCommand, UiCommand, Props>(app))
             .add_system_to_stage(CoreStage::PostUpdate, send_ui_commands::<UiCommand>)
-            .add_system_to_stage(CoreStage::PostUpdate, rerender_dom)
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 change_window, /* TODO.label(ModifiesWindows) // is recentry introduced ( > 0.7 ) */
@@ -245,26 +244,6 @@ where
                 id: create_window_event.id,
             });
         }
-    }
-}
-
-fn rerender_dom(tx: Res<Sender<VDomCommand>>) {
-    match tx.try_send(VDomCommand::UpdateDom) {
-        Ok(()) => {}
-        Err(e) => match e {
-            TrySendError::Full(e) => {
-                error!(
-                    "Failed to send VDomCommand: channel is full: event: {:?}",
-                    e
-                );
-            }
-            TrySendError::Closed(e) => {
-                error!(
-                    "Failed to send VDomCommand: channel is closed: event: {:?}",
-                    e
-                );
-            }
-        },
     }
 }
 

--- a/packages/desktop/src/runner.rs
+++ b/packages/desktop/src/runner.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event::{KeyboardEvent, UiEvent, VDomCommand, WindowEvent},
+    event::{KeyboardEvent, UiEvent, WindowEvent},
     setting::{DioxusSettings, UpdateMode},
     window::DioxusWindows,
 };
@@ -19,7 +19,7 @@ use bevy::{
         WindowMoved, WindowResized, WindowScaleFactorChanged, Windows,
     },
 };
-use futures_intrusive::channel::shared::{Receiver, Sender};
+use futures_intrusive::channel::shared::Receiver;
 use std::fmt::Debug;
 use tokio::runtime::Runtime;
 use wry::application::{
@@ -34,6 +34,7 @@ where
     UiCommand: 'static + Send + Sync + Clone + Debug,
     Props: 'static + Send + Sync + Clone + Default,
 {
+    println!("runner");
     let event_loop = app
         .world
         .remove_non_send_resource::<EventLoop<UiEvent<CoreCommand>>>()
@@ -57,6 +58,7 @@ where
         move |event: Event<UiEvent<CoreCommand>>,
               _event_loop: &EventLoopWindowTarget<UiEvent<CoreCommand>>,
               control_flow: &mut ControlFlow| {
+            log::debug!("{event:?}");
             match event {
                 Event::NewEvents(start) => {
                     let dioxus_settings = app.world.non_send_resource::<DioxusSettings<Props>>();
@@ -408,12 +410,10 @@ where
                     } else {
                         false
                     };
-                    let vdom_cmd_tx = app.world.get_resource::<Sender<VDomCommand>>().unwrap();
 
                     if update {
                         tao_state.last_update = Instant::now();
-
-                        let _ = vdom_cmd_tx.try_send(VDomCommand::UpdateDom);
+                        log::debug!("app.update()");
                         app.update();
                     }
                 }

--- a/packages/desktop/src/runner.rs
+++ b/packages/desktop/src/runner.rs
@@ -414,7 +414,6 @@ where
                         tao_state.last_update = Instant::now();
 
                         let _ = vdom_cmd_tx.try_send(VDomCommand::UpdateDom);
-                        println!("update");
                         app.update();
                     }
                 }

--- a/packages/desktop/src/runner.rs
+++ b/packages/desktop/src/runner.rs
@@ -34,7 +34,6 @@ where
     UiCommand: 'static + Send + Sync + Clone + Debug,
     Props: 'static + Send + Sync + Clone + Default,
 {
-    println!("runner");
     let event_loop = app
         .world
         .remove_non_send_resource::<EventLoop<UiEvent<CoreCommand>>>()

--- a/packages/desktop/src/window.rs
+++ b/packages/desktop/src/window.rs
@@ -1,27 +1,23 @@
 use crate::{
-    context::{ProxyType, UiContext},
-    event::{trigger_from_serialized, IpcMessage, KeyboardEvent, UiEvent, UpdateDom, WindowEvent},
+    context::ProxyType,
+    event::{trigger_from_serialized, IpcMessage, KeyboardEvent, UiEvent, WindowEvent},
     protocol,
     setting::DioxusSettings,
 };
 use bevy::{
-    ecs::{component::Component, world::WorldCell},
+    ecs::world::WorldCell,
     math::IVec2,
     utils::HashMap,
     window::{Window as BevyWindow, WindowDescriptor, WindowId, WindowMode},
 };
-use dioxus_core::{Component as DioxusComponent, SchedulerMsg, VirtualDom};
-use fermi::{Atom, AtomRoot, Readable};
+use dioxus_core::SchedulerMsg;
 use futures_channel::mpsc;
-use futures_intrusive::channel::shared::{Receiver, Sender};
 use raw_window_handle::HasRawWindowHandle;
 use std::{
     fmt::{self, Debug},
     marker::PhantomData,
-    rc::Rc,
     sync::{atomic::AtomicBool, Arc, Mutex},
 };
-use tokio::runtime::Runtime;
 use wry::{
     application::{
         dpi::{LogicalPosition, LogicalSize},
@@ -32,13 +28,6 @@ use wry::{
     },
     webview::{WebView, WebViewBuilder},
 };
-
-/// TODO: move to example side
-#[derive(Component, Default)]
-pub struct Count(pub u32);
-
-/// TODO: should be derived by macro
-pub static COUNT: Atom<Count> = |_| Count::default();
 
 #[derive(Default)]
 pub struct DioxusWindows {
@@ -82,7 +71,7 @@ impl DioxusWindows {
         self.tao_to_window_id.get(&id).cloned()
     }
 
-    pub fn create<CoreCommand, UiCommand, Props>(
+    pub fn create<CoreCommand, Props>(
         &mut self,
         world: &WorldCell,
         window_id: WindowId,
@@ -90,20 +79,24 @@ impl DioxusWindows {
     ) -> BevyWindow
     where
         CoreCommand: 'static + Send + Sync + Clone + Debug,
-        UiCommand: 'static + Send + Sync + Clone + Debug,
         Props: 'static + Send + Sync + Clone,
     {
         let event_loop = world
             .get_non_send_mut::<EventLoop<UiEvent<CoreCommand>>>()
             .unwrap();
         let proxy = event_loop.create_proxy();
+        let dom_tx = world
+            .get_resource::<mpsc::UnboundedSender<SchedulerMsg>>()
+            .unwrap();
+        let edit_queue = world
+            .get_resource::<Arc<Mutex<Vec<String>>>>()
+            .unwrap()
+            .clone();
 
         let tao_window = Self::create_tao_window::<CoreCommand>(&event_loop, &window_descriptor);
         let tao_window_id = tao_window.id();
 
         let bevy_window = Self::create_bevy_window(window_id, &tao_window, &window_descriptor);
-        let (dom_tx, edit_queue) =
-            Self::spawn_virtual_dom::<CoreCommand, UiCommand, Props>(world, proxy.clone());
         let (webview, is_ready) = Self::create_webview::<CoreCommand, Props>(
             world,
             window_descriptor,
@@ -114,7 +107,7 @@ impl DioxusWindows {
 
         self.windows.insert(
             tao_window_id,
-            Window::new(webview, dom_tx, is_ready, edit_queue),
+            Window::new(webview, dom_tx.clone(), is_ready, edit_queue),
         );
         self.window_id_to_tao.insert(window_id, tao_window_id);
         self.tao_to_window_id.insert(tao_window_id, window_id);
@@ -273,80 +266,6 @@ impl DioxusWindows {
                 .map(|position| IVec2::new(position.x, position.y)),
             tao_window.raw_window_handle(),
         )
-    }
-
-    fn spawn_virtual_dom<CoreCommand, UiCommand, Props>(
-        world: &WorldCell,
-        proxy: ProxyType<CoreCommand>,
-    ) -> (mpsc::UnboundedSender<SchedulerMsg>, Arc<Mutex<Vec<String>>>)
-    where
-        CoreCommand: 'static + Send + Sync + Clone + Debug,
-        UiCommand: 'static + Send + Sync + Clone + Debug,
-        Props: 'static + Send + Sync + Clone,
-    {
-        let root = world
-            .get_resource::<DioxusComponent<Props>>()
-            .unwrap()
-            .clone();
-        let settings = world.get_non_send::<DioxusSettings<Props>>().unwrap();
-        let props = settings.props.as_ref().unwrap().clone();
-        let core_tx = world.get_resource::<Sender<CoreCommand>>().unwrap().clone();
-        let ui_rx = world.get_resource::<Receiver<UiCommand>>().unwrap().clone();
-        let dom_update_rx = world.get_resource::<Receiver<UpdateDom>>().unwrap().clone();
-
-        let (dom_tx, dom_rx) = mpsc::unbounded::<SchedulerMsg>();
-        let context = UiContext::<CoreCommand, UiCommand>::new(proxy.clone(), (core_tx, ui_rx));
-        let edit_queue = Arc::new(Mutex::new(Vec::new()));
-
-        let dom_tx_clone = dom_tx.clone();
-        let edit_queue_clone = edit_queue.clone();
-
-        std::thread::spawn(move || {
-            Runtime::new().unwrap().block_on(async move {
-                let mut dom =
-                    VirtualDom::new_with_props_and_scheduler(root, props, (dom_tx_clone, dom_rx));
-
-                dom.base_scope().provide_context(context.clone());
-
-                let edits = dom.rebuild();
-
-                edit_queue_clone
-                    .lock()
-                    .unwrap()
-                    .push(serde_json::to_string(&edits.edits).unwrap());
-
-                let cx = dom.base_scope();
-                let root = match cx.consume_context::<Rc<AtomRoot>>() {
-                    Some(root) => root,
-                    None => {
-                        cx.provide_root_context(Rc::new(AtomRoot::new(cx.schedule_update_any())))
-                    }
-                };
-                let id = COUNT.unique_id();
-                root.initialize(COUNT);
-                root.set(id, Count(100));
-
-                proxy
-                    .send_event(UiEvent::WindowEvent(WindowEvent::Update))
-                    .unwrap();
-
-                while let Some(_) = dom_update_rx.receive().await {
-                    dom.wait_for_work().await;
-
-                    let muts = dom.work_with_deadline(|| false);
-                    for edit in muts {
-                        edit_queue_clone
-                            .lock()
-                            .unwrap()
-                            .push(serde_json::to_string(&edit.edits).unwrap());
-                    }
-
-                    let _ = proxy.send_event(UiEvent::WindowEvent(WindowEvent::Update));
-                }
-            });
-        });
-
-        (dom_tx, edit_queue)
     }
 
     fn create_webview<CoreCommand, Props>(

--- a/packages/macro/Cargo.toml
+++ b/packages/macro/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bevy_dioxus_macro"
+version = "0.1.0"
+authors = ["Junichi Sugiura"]
+edition = "2021"
+description = "Write Cross-platform application with React-like decralative UI framework and scalable ECS architecture all in Rust."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/JunichiSugiura/bevy_dioxus/"
+homepage = "https://github.com/JunichiSugiura/bevy_dioxus/"
+documentation = "https://docs.rs/bevy_dioxus/latest/bevy_dioxus/"
+keywords = ["declarative-ui", "ecs", "bevy", "dioxus", "cross-platform"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+fermi = "0.2"
+lazy_static = "1.4"
+quote = "1.0"
+syn = { version="1.0", features = [ "full", "fold" ]}

--- a/packages/macro/src/lib.rs
+++ b/packages/macro/src/lib.rs
@@ -1,0 +1,107 @@
+#[macro_use]
+extern crate lazy_static;
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use std::sync::Mutex;
+use syn::{parse_macro_input, DeriveInput};
+
+lazy_static! {
+    static ref DEPS: Mutex<Vec<String>> = Mutex::new(Default::default());
+}
+
+#[proc_macro_derive(GlobalState)]
+pub fn global_atom(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    DEPS.lock().as_mut().unwrap().push(input.ident.to_string());
+
+    let name = &input.ident;
+    let atom_name = format_ident!("{}", &name.to_string().to_uppercase());
+
+    let gen = quote! {
+        static #atom_name: Atom<#name> = |_| #name::default();
+    };
+
+    gen.into()
+}
+
+#[proc_macro_derive(GlobalStatePlugin)]
+pub fn derive_global_state_plugin(_input: TokenStream) -> TokenStream {
+    let mut enum_inners = vec![];
+    let mut handler_inners = vec![];
+    let mut systems = vec![];
+    let mut add_systems = vec![];
+
+    for name in DEPS.lock().unwrap().iter() {
+        let atom_name = format_ident!("{}", name.to_uppercase());
+        let system_name = format_ident!("apply_{}", name.to_lowercase());
+        let name = format_ident!("{}", name);
+
+        let enum_inner = quote! { #name(#name) };
+        let handler_inner = quote! { GlobalState::#name(x) => root.set(#atom_name.unique_id(), x) };
+        let system = quote! {
+            fn #system_name(
+                query: Query<&#name, Changed<#name>>,
+                vdom_tx: Res<Sender<VDomCommand<GlobalState>>>,
+            ) {
+                for x in query.iter() {
+                    match vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::#name(x.clone()))) {
+                        Ok(()) => {}
+                        Err(e) => match e {
+                            TrySendError::Full(e) => {
+                                error!(
+                                    "Failed to send VDomCommand: channel is full: event: {:?}",
+                                    e
+                                );
+                            }
+                            TrySendError::Closed(e) => {
+                                error!(
+                                    "Failed to send VDomCommand: channel is closed: event: {:?}",
+                                    e
+                                );
+                            }
+                        },
+                    }
+                }
+            }
+        };
+        let add_system = quote! {
+            app.add_system(#system_name);
+        };
+
+        enum_inners.push(enum_inner);
+        handler_inners.push(handler_inner);
+        systems.push(system);
+        add_systems.push(add_system);
+    }
+
+    let gen = quote! {
+        use dioxus::fermi::{AtomRoot, Readable};
+        use std::rc::Rc;
+
+        #[derive(Debug)]
+        enum GlobalState {
+            #(#enum_inners),*
+        }
+
+        impl GlobalStateHandler for GlobalState {
+            fn handler(self, root: Rc<AtomRoot>) {
+                match self {
+                    #(#handler_inners),*
+                }
+            }
+        }
+
+        impl Plugin for GlobalStatePlugin {
+            fn build(&self, app: &mut App) {
+                #(#add_systems)*;
+            }
+        }
+
+        #(#systems)*;
+
+    };
+
+    gen.into()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+pub use bevy_dioxus_core as core;
 #[cfg(feature = "desktop")]
 pub use bevy_dioxus_desktop as desktop;
+pub use bevy_dioxus_macro as macros;


### PR DESCRIPTION
close #8 

This PR introduces `GlobalStatePlugin` macro (also struct) which allows ECS component to be exposed as reactive global state on UI side automagically.

### Example
```rust
fn main() {
  App:new()
    .add_plugin(GlobalStatePlugin)
    .add_plugin(DioxusPlugin::<GlobalState, CoreCommand, ()>::new(Root))
    .run()
}

fn Root(cx: Scope) -> Element {
    let count = use_read(&cx, COUNT); // <- consume global state with hook
    let window = use_window::<CoreCommand, ()>(&cx);

    cx.render(rsx! {
        h1 { "Counter Example" }
        p { "count: {count.0}" }
        button {
            onclick: move |_| window.send(CoreCommand::Decrement),
            "-",
        }
        button {
            onclick: move |_| window.send(CoreCommand::Increment),
            "+",
        }
    })
}

#[derive(Component, Clone, Default, GlobalState)] // <- you can derive multiple global values.
struct Count(u32);

// Warning: Execution order matters here. Make sure to place this line after deriving all GlobalState.
#[derive(GlobalStatePlugin)]
struct GlobalStatePlugin;

//###########################################################
// What macro generates for you ↓
//###########################################################

static COUNT: Atom<Count> = |_| Count::default();

enum GlobalState {
  Count(Count)
}

impl GlobalStateHandler for GlobalState {
  fn handler(self, root: Rc<AtomRoot>) {
    match self {
      GlobalState::Count(x) => root.set(COUNT.unique_id(), x),
    }
  }
}

impl Plugin for GlobalStatePlugin {
  fn build(&self, app: &mut App) {
    app.add_system(apply_count);
  }
}

fn apply_count(
  query: Query<Count, Changed<Count>>,
  vdom_tx: Res<Sender<VDomCommand<GlobalState>>>,
) {
  for x in query.iter() {
    vdom_tx.try_send(VDomCommand::GlobalState(GlobalState::Count(x.clone()))).unwrap();
  }
}

```


There's also `EmptyGlobalState` for when you don't need to set any value.
```rust
fn main() {
  App::new()
    .add_plugin(DioxusPlugin::<EmptyGlobalState, (), ()>::new(Root))
    .run();
}
```