### PR TITLE
Upgrade WRY to v0.19

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -29,8 +29,8 @@ serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"
 tokio = { version = "1.18", features = ["rt-multi-thread", "macros"], default-features = false }
-webbrowser = "0.5"
-wry = "0.16"
+webbrowser = "0.7"
+wry = "0.19"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"


### PR DESCRIPTION
Refs: #30 

- WRY: v0.16 -> v0.19
  - v0.20 requires [raw-window-handle v0.5](https://github.com/rust-windowing/raw-window-handle) but `bevy_window` still depends on v0.4
- webbrowser: v0.5 -> 0.8