### PR TITLE
Make TodoMVC as a private crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ dip_macro = { version = "0.1", path = "./packages/macro" }
 dip_cli = { version = "0.1", path = "./packages/cli" }
 
 [dev-dependencies]
-chrono = "0.4"
 leafwing-input-manager = { version = "0.5", default-features = false }
 
 [features]
@@ -33,6 +32,7 @@ members = [
     "packages/core",
     "packages/desktop",
     "packages/macro",
+    "examples/todomvc",
 ]
 
 [[example]]
@@ -54,10 +54,6 @@ path = "examples/state_management/global_state.rs"
 [[example]]
 name = "ecs"
 path = "examples/state_management/ecs.rs"
-
-[[example]]
-name = "todomvc"
-path = "examples/todomvc/main.rs"
 
 [[example]]
 name = "window_settings"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 > WARNING: `dip` is still in the very early stages of development.
 
 ```rust, no_run
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,4 +1,4 @@
-use dip::{bevy::log::LogPlugin, desktop::prelude::*};
+use dip::{bevy::log::LogPlugin, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/keyboard/bindings.rs
+++ b/examples/keyboard/bindings.rs
@@ -5,7 +5,7 @@ use dip::{
         time::TimePlugin,
         window::{WindowCloseRequested, WindowId},
     },
-    desktop::prelude::*,
+    prelude::*,
 };
 use leafwing_input_manager::prelude::*;
 

--- a/examples/keyboard/keyboard_event.rs
+++ b/examples/keyboard/keyboard_event.rs
@@ -1,6 +1,6 @@
 use dip::{
     bevy::{input::keyboard::KeyboardInput, log::LogPlugin},
-    desktop::prelude::*,
+    prelude::*,
 };
 
 fn main() {

--- a/examples/minimum.rs
+++ b/examples/minimum.rs
@@ -1,4 +1,4 @@
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/root_props.rs
+++ b/examples/root_props.rs
@@ -1,4 +1,4 @@
-use dip::{bevy::log::LogPlugin, desktop::prelude::*};
+use dip::{bevy::log::LogPlugin, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/state_management/ecs.rs
+++ b/examples/state_management/ecs.rs
@@ -1,4 +1,4 @@
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/state_management/global_state.rs
+++ b/examples/state_management/global_state.rs
@@ -1,4 +1,4 @@
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/state_management/local_state.rs
+++ b/examples/state_management/local_state.rs
@@ -1,4 +1,4 @@
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "todomvc"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+chrono = "0.4"
+dip = { version = "0.1", path = "../..", features = ["desktop"] }
+
+# Removing this line will throw error in `./src/component.rs`.
+# This is because some derive macros generates code using sub crate name instead of root (i.e. bevy_ecs::Component vs bevy::ecs::Compoent)
+bevy_ecs = "0.8"
+
+[[bin]]
+name = "todomvc"
+path = "src/main.rs"

--- a/examples/todomvc/src/component.rs
+++ b/examples/todomvc/src/component.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 // Component Bundle
 #[derive(Bundle, Default)]

--- a/examples/todomvc/src/event.rs
+++ b/examples/todomvc/src/event.rs
@@ -1,5 +1,5 @@
 use crate::ui_state::UiTodo;
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 // Internal events (System -> System)
 

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -5,24 +5,25 @@ mod ui;
 mod ui_state;
 
 use crate::{event::*, system::*, ui::Root, ui_state::*};
-use dip::{bevy::log::LogPlugin, desktop::prelude::*};
+use dip::{bevy::log::LogPlugin, prelude::*};
 use std::{fs, process::Command};
 
 fn main() {
     // quick and dirty way to compile tailwind css on each run
     let script = "npm run todomvc:css";
-    if cfg!(target_os = "windows") {
+    let cmd = if cfg!(target_os = "windows") {
         Command::new("cmd")
             .args(["/C", script])
             .output()
-            .expect("failed to execute process");
+            .expect("failed to execute process")
     } else {
         Command::new("sh")
             .arg("-c")
             .arg(script)
             .output()
-            .expect("failed to execute process");
+            .expect("failed to execute process")
     };
+    info!("{cmd:#?}");
 
     let css = fs::read_to_string("examples/todomvc/public/main.css")
         .expect("Should have been able to read the file");

--- a/examples/todomvc/src/system.rs
+++ b/examples/todomvc/src/system.rs
@@ -1,5 +1,5 @@
 use crate::{component::*, event::*, ui_state::*};
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 pub fn new_ui_todo_list(
     mut events: EventReader<NewUiTodoListRequested>,

--- a/examples/todomvc/src/ui.rs
+++ b/examples/todomvc/src/ui.rs
@@ -1,5 +1,5 @@
 use crate::ui_state::*;
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 #[allow(non_snake_case)]
 pub fn Root(cx: Scope) -> Element {

--- a/examples/todomvc/src/ui_state.rs
+++ b/examples/todomvc/src/ui_state.rs
@@ -1,6 +1,6 @@
 use crate::component::*;
 use chrono::{DateTime, Utc};
-use dip::desktop::prelude::*;
+use dip::prelude::*;
 
 #[ui_state]
 pub struct UiState {

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -3,7 +3,7 @@ use dip::{
         log::LogPlugin,
         window::{CreateWindow, WindowDescriptor, WindowId},
     },
-    desktop::prelude::*,
+    prelude::*,
 };
 
 /// This example attemps to create a second window then warning shows up

--- a/examples/window/render_mode.rs
+++ b/examples/window/render_mode.rs
@@ -3,7 +3,7 @@ use dip::{
         log::{self, LogPlugin},
         time::TimePlugin,
     },
-    desktop::prelude::*,
+    prelude::*,
 };
 
 /// This example illustrates how to customize render setting

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -1,4 +1,4 @@
-use dip::{bevy::log::LogPlugin, desktop::prelude::*};
+use dip::{bevy::log::LogPlugin, prelude::*};
 
 /// This example open window with specific size then resize
 fn main() {

--- a/examples/window/settings.rs
+++ b/examples/window/settings.rs
@@ -1,6 +1,6 @@
 use dip::{
     bevy::{log::LogPlugin, time::TimePlugin, window::PresentMode},
-    desktop::prelude::*,
+    prelude::*,
 };
 
 /// This example illustrates how to customize the default window settings

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -13,5 +13,3 @@ keywords = ["declarative-ui", "ecs", "bevy", "dioxus", "cross-platform"]
 [dependencies]
 bevy = { version = "0.8", default-features = false }
 dioxus = { version = "0.2", features = ["fermi"] }
-
-dip_macro = { version = "0.1", path = "../macro"}

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -8,7 +8,4 @@ pub mod prelude {
         schedule::{UiSchedulePlugin, UiStage},
         ui_state::{NoRootProps, NoUiAction, NoUiState, UiStateHandler},
     };
-    pub use bevy::prelude::*;
-    pub use dioxus::prelude::*;
-    pub use dip_macro::*;
 }

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -25,5 +25,4 @@ pub mod prelude {
         plugin::DesktopPlugin,
         setting::{DesktopSettings, UpdateMode},
     };
-    pub use dip_core::prelude::*;
 }

--- a/packages/desktop/src/plugin.rs
+++ b/packages/desktop/src/plugin.rs
@@ -110,7 +110,7 @@ where
     /// Initialize DioxusPlugin with root component and channel types
     ///
     /// ```no_run
-    /// use dip::desktop::prelude::*;
+    /// use dip::prelude::*;
     ///
     /// fn main() {
     ///    App::new()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,21 @@
 
 pub use dip_cli as cli;
 pub use dip_core as core;
+pub use dip_macro as macros;
+
 #[cfg(feature = "desktop")]
 pub use dip_desktop as desktop;
-pub use dip_macro as macros;
 
 pub use bevy;
 pub use dioxus;
+
+///
+pub mod prelude {
+    pub use bevy::prelude::*;
+    pub use dioxus::prelude::*;
+    pub use dip_core::prelude::*;
+    pub use dip_macro::*;
+
+    #[cfg(feature = "desktop")]
+    pub use dip_desktop::prelude::*;
+}


### PR DESCRIPTION
close #78 

- Now all prelude comes from `dip::prelude::*` instead of `dip::desktop::prelude::*`.
- Limitation: user still need to add `bevy_ecs` as a dependency because bevy derive macro uses `bevy_ecs` name space instead of `bevy::ecs`.